### PR TITLE
Add CT defacing support and update to v0.3.3

### DIFF
--- a/caideface/pyproject.toml
+++ b/caideface/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caideface"
-version = "0.3.2"
+version = "0.3.3"
 description = "MRI defacing pipeline with skull-stripping and affine registration from cai4cai"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/caideface/src/caideface/__init__.py
+++ b/caideface/src/caideface/__init__.py
@@ -8,7 +8,7 @@ A three-step pipeline for anonymising head MRI scans:
 Plus standalone text anonymisation via NER + HIPS (Hiding in Plain Sight).
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 from .pipeline import DefacePipeline
 from .reorient import reorient_batch, reorient_single


### PR DESCRIPTION
- CT defacing pipeline with TotalSegmentator for brain extraction (`pip install caideface[ct]`)
- Required `--modality {mri,ct}` flag across all pipeline commands
- Per-volume background value auto-detection from histogram analysis
- CT face mask and modality-aware template selection
- Fix reorientation to RAS for both MRI and CT (matches fslreorient2std)
- Bump to v0.3.3